### PR TITLE
[fix] fix index out of range in RouteDetailView when API response late

### DIFF
--- a/WidgetBus/Views/RouteDetailView/RouteDetailViewController.swift
+++ b/WidgetBus/Views/RouteDetailView/RouteDetailViewController.swift
@@ -255,23 +255,22 @@ extension RouteDetailViewController: UITableViewDataSource {
                 cell.highlightView.isHidden = true
             }
 
-            if(busLocationList[busLocationListIndex].nodeord == cellData.nodeord
-               && busLocationListIndex + 1 < busLocationList.count) {
-                cell.busView2.isHidden = false
-                busLocationListIndex += 1
-                busLocationIndexPath.append(indexPath.row)
-                print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!indexPath.row : \(indexPath.row)")
+            cell.busView2.isHidden = true
+            if(busLocationList.isEmpty) {
+                print("busLocationList 불러오는 중")
             } else {
-                cell.busView2.isHidden = true
-            }
+                if(busLocationList[busLocationListIndex].nodeord == cellData.nodeord
+                   && busLocationListIndex + 1 < busLocationList.count) {
+                    busLocationListIndex += 1
+                    busLocationIndexPath.append(indexPath.row)
+                }
 
-            if(busLocationIndexPath.contains(indexPath.row)) {
-                cell.busView2.isHidden = false
-                print("!===================================indexPath.row : \(indexPath.row)")
-            } else {
-                cell.busView2.isHidden = true
+                if(busLocationIndexPath.contains(indexPath.row)) {
+                    cell.busView2.isHidden = false
+                } else {
+                    cell.busView2.isHidden = true
+                }
             }
-
             //            if(cellData.nodeord > route.startNodeId && cellData.nodeord < route.endNodeId) {
             //                cell.routeLineView.backgroundColor = .duduDeepBlue
             //            } else {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #47 


## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
getLocationsOnRoute API가 지연될 때 index out of range발생을 고쳣습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
getLocationsOnRoute API가 지연될 때 index out of range발생을 고쳣습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
API부분을 주석처리하고 실행 시 busLocationList 불러오는 중이 출력됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-22 at 15 16 06](https://user-images.githubusercontent.com/67789254/203239075-9c6b5f97-0032-489d-b942-b2ff1739224c.gif)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
