### PR TITLE
Feat/select start node view

### DIFF
--- a/WidgetBus/Views/SelectStartNodeView/SelectStartNodeViewController.swift
+++ b/WidgetBus/Views/SelectStartNodeView/SelectStartNodeViewController.swift
@@ -131,7 +131,7 @@ final class SelectStartNodeViewController: UIViewController, UITableViewDelegate
     private func addDefaultKeyboardObserver() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(keyboardWillHide(_:)),
+            selector: #selector(keyboardWillHide),
             name: UIResponder.keyboardWillHideNotification,
             object: nil
         )

--- a/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.swift
+++ b/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.swift
@@ -8,13 +8,18 @@
 import MapKit
 import UIKit
 
-final class SelectStartNodeTableViewCell: UITableViewCell {
+final class SelectStartNodeTableViewCell: UITableViewCell, MKMapViewDelegate {
 
     @IBOutlet weak var nodeName: UILabel!
     @IBOutlet weak var nodeDirection: UILabel!
     @IBOutlet weak var nodeDistance: UILabel!
 
     @IBOutlet weak var mapView: MKMapView!
+
+    private let nodeCoordinate = CLLocationCoordinate2D(
+        latitude: 36.014099310928216,
+        longitude: 129.32591317393107
+    )
 
     static func nib() -> UINib {
         return UINib(nibName: "SelectStartNodeTableViewCell", bundle: nil)
@@ -33,12 +38,58 @@ final class SelectStartNodeTableViewCell: UITableViewCell {
         super.prepareForReuse()
 
         mapView.isHidden = true
+        mapView.removeAnnotations(mapView.annotations)
         self.backgroundColor = .clear
     }
 
     // MARK: 셀 확장 설정
+
     func settingData(isClicked: Bool) {
         mapView.isHidden = !isClicked
         self.backgroundColor = isClicked ? .duduBlue : .clear
+        if isClicked {
+            addCustomPin()
+            mapView.setRegion(
+                MKCoordinateRegion(
+                    center: nodeCoordinate,
+                    span: MKCoordinateSpan(
+                        latitudeDelta: 0.005,
+                        longitudeDelta: 0.005
+                    )
+                ),
+                animated: false
+            )
+        }
+    }
+
+    // MARK: 어노테이션 설정
+
+    func addCustomPin() {
+        let pin = MKPointAnnotation()
+        pin.coordinate = nodeCoordinate
+        pin.title = nodeName.text
+        pin.subtitle = nodeDirection.text
+        mapView.addAnnotation(pin)
+    }
+
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard !annotation.isKind(of: MKUserLocation.self) else {
+            return nil
+        }
+
+        var annotationView =
+        mapView.dequeueReusableAnnotationView(withIdentifier: "BusNode") as? MKMarkerAnnotationView
+
+        if annotationView == nil {
+            annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: "BusNode")
+        } else {
+            annotationView?.annotation = annotation
+        }
+
+        annotationView?.glyphImage = UIImage(systemName: "bus.fill")
+        annotationView?.markerTintColor = .duduDeepBlue
+        annotationView?.canShowCallout = false
+
+        return annotationView
     }
 }

--- a/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.swift
+++ b/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.swift
@@ -64,7 +64,7 @@ final class SelectStartNodeTableViewCell: UITableViewCell, MKMapViewDelegate {
 
     // MARK: 어노테이션 설정
 
-    func addCustomPin() {
+    private func addCustomPin() {
         let pin = MKPointAnnotation()
         pin.coordinate = nodeCoordinate
         pin.title = nodeName.text

--- a/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.xib
+++ b/WidgetBus/Views/SelectStartNodeView/TableViewCell/SelectStartNodeTableViewCell.xib
@@ -25,10 +25,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="32.333333333333336"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="P8a-71-kre" userLabel="Node Info Stack View">
-                                        <rect key="frame" x="8" y="0.0" width="69.333333333333329" height="32.333333333333336"/>
+                                        <rect key="frame" x="8" y="0.0" width="86" height="32.333333333333336"/>
                                         <subviews>
                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="정류장 이름" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="aPW-LQ-Mmw">
-                                                <rect key="frame" x="0.0" y="0.0" width="69.333333333333329" height="14.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="86" height="14"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
@@ -64,6 +64,9 @@
                                     <constraint firstAttribute="width" secondItem="1TU-A3-Kdf" secondAttribute="height" multiplier="32:29" id="0Oh-5I-8td"/>
                                 </constraints>
                                 <standardMapConfiguration key="preferredConfiguration"/>
+                                <connections>
+                                    <outlet property="delegate" destination="KGk-i7-Jjw" id="GEr-Dy-ikZ"/>
+                                </connections>
                             </mapView>
                         </subviews>
                     </stackView>


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #11 


## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
주어진 좌표에 버스 정류장 마크를 표시해주어야 합니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 각 셀을 확장할 때 셀의 주어진 좌표에 마커 어노테이션을 추가합니다.
- 셀이 리유즈 될 때 어노테이션을 삭제합니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
셀에서 지도의 동작 관련해서 테스트 부탁드립니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src = "https://user-images.githubusercontent.com/33440010/203779771-8aafd582-5f6b-40ed-b89a-a7e0c36be0b8.png" width = "30%">



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 지도가 작아서 화면이 작은 기기를 사용하면 잘 안보일 수 있다는 피드백을 받음 (셀 선택 시 스크롤과 함께 그 셀의 Height를 테이블뷰와 같게 만들어보면 어떨까?)
- 셀의 높이가 변할 때 셀이 리로드 되면서 셀이 리유즈 된다. 이 때문에 셀에 저장된 맵의 정보가 서로 섞이게 되는 문제가 발생. 일단 셀의 맵이 리로드 될 때 초기화 될 수 있도록 만들었지만 셀의 리로드 없이 높이를 조절하도록 변경 필요.


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[[iOS/Swift] MKMapKit, CLCoreLocation 으로 지도앱 만들기](https://ios-developer-storage.tistory.com/entry/MKMapKit-CLCoreLocation-예시로-쉽게-이해하기-다운로드-제공)